### PR TITLE
Updates Primogen Agelocks, matching current rules

### DIFF
--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/banu_haqim.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/banu_haqim.dm
@@ -23,7 +23,7 @@
 	)
 
 	minimal_generation = 12
-	minimum_immortal_age = 100
+	minimum_immortal_age = 100 // TFN EDIT ADDITION
 	minimal_masquerade = 5
 	allowed_splats = list(SPLAT_KINDRED)
 	allowed_clans = list(VAMPIRE_CLAN_BANU_HAQIM)

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/lasombra.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/lasombra.dm
@@ -24,7 +24,7 @@
 	)
 
 	minimal_generation = 12
-	minimum_immortal_age = 100
+	minimum_immortal_age = 100 // TFN EDIT ADDITION
 	minimal_masquerade = 5
 	allowed_splats = list(SPLAT_KINDRED)
 	allowed_clans = list(VAMPIRE_CLAN_LASOMBRA)

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/malkavian.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/malkavian.dm
@@ -24,7 +24,7 @@
 	)
 
 	minimal_generation = 12
-	minimum_immortal_age = 100
+	minimum_immortal_age = 100 // TFN EDIT ADDITION
 	minimal_masquerade = 5
 	allowed_splats = list(SPLAT_KINDRED)
 	allowed_clans = list(VAMPIRE_CLAN_MALKAVIAN)

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/nosferatu.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/nosferatu.dm
@@ -24,7 +24,7 @@
 	)
 
 	minimal_generation = 12
-	minimum_immortal_age = 100
+	minimum_immortal_age = 100 // TFN EDIT ADDITION
 	minimal_masquerade = 5
 	allowed_splats = list(SPLAT_KINDRED)
 	allowed_clans = list(VAMPIRE_CLAN_NOSFERATU)

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/toreador.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/toreador.dm
@@ -24,7 +24,7 @@
 	)
 
 	minimal_generation = 12
-	minimum_immortal_age = 100
+	minimum_immortal_age = 100 // TFN EDIT ADDITION
 	minimal_masquerade = 5
 	allowed_splats = list(SPLAT_KINDRED)
 	allowed_clans = list(VAMPIRE_CLAN_TOREADOR)

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/ventrue.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/ventrue.dm
@@ -23,7 +23,7 @@
 	)
 
 	minimal_generation = 12
-	minimum_immortal_age = 100
+	minimum_immortal_age = 100 // TFN EDIT ADDITION
 	minimal_masquerade = 5
 	allowed_splats = list(SPLAT_KINDRED)
 	allowed_clans = list(VAMPIRE_CLAN_VENTRUE)


### PR DESCRIPTION
## About The Pull Request
Simply changes all Primogen Minimum Age reqs to be 100+, using "minimum_immortal_age". Mirroring from non-rebase!

## Why It's Good For The Game
It's good to have code match the actual rules, so just quickly making this PR to hopefully fix that!

## Testing Photographs and Procedure
Too young
<img width="260" height="23" alt="image" src="https://github.com/user-attachments/assets/e3ab0a4b-f4fe-4e8a-858f-bc65532ab7f1" />
<img width="342" height="95" alt="image" src="https://github.com/user-attachments/assets/86688d31-de5d-4c1a-b9eb-0a43594e1cad" />

Older
<img width="270" height="51" alt="image" src="https://github.com/user-attachments/assets/674326d6-399a-4621-af50-743d0552c60a" />
<img width="349" height="217" alt="image" src="https://github.com/user-attachments/assets/3737e743-f691-44a7-9e7e-0995260e12bb" />


## Changelog

:cl:
add: Re-adjust Primogen Minimum Age to be 100+
/:cl:

