### PR TITLE
hard deletes

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/__discipline.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline.dm
@@ -53,6 +53,16 @@
 		known_powers += new_power
 	current_power = known_powers[1]
 
+// TFN EDIT START - harddels
+/datum/discipline/Destroy()
+	current_power = null
+	if(owner)
+		UnregisterSignal(owner, COMSIG_QDELETING)
+		owner = null
+	QDEL_LIST(known_powers)
+	return ..()
+// TFN EDIT END - harddels
+
 /**
  * Modifies a Discipline's level, updating its available powers
  * to conform to the new level. This proc will be removed when
@@ -102,13 +112,13 @@
 	post_gain_applied = TRUE
 
 	// Destroy self and contained powers when owner is destroyed
-	RegisterSignal(owner, COMSIG_QDELETING, PROC_REF(on_owner_destroy))
+	//RegisterSignal(owner, COMSIG_QDELETING, PROC_REF(on_owner_destroy))
 
 /**
  * When the Discipline's owner is destroyed, this deletes all
  * contained powers, clears out references to the destroyed owner,
  * and then deletes itself.
- */
+
 /datum/discipline/proc/on_owner_destroy(mob/living/source, force)
 	SIGNAL_HANDLER
 
@@ -119,7 +129,7 @@
 	// Destroy self when owner is destroyed
 	owner = null
 	qdel(src)
-
+*/
 /**
  * Returns a known Discipline power in this Discipline
  * searching by type.

--- a/modular_darkpack/modules/powers/code/discipline/__discipline_power.dm
+++ b/modular_darkpack/modules/powers/code/discipline/__discipline_power.dm
@@ -69,6 +69,19 @@
 	src.discipline = discipline
 	src.owner = discipline.owner
 
+//TFN EDIT ADD - Harddels
+/datum/discipline_power/Destroy()
+	if(cooldown_timer)
+		deltimer(cooldown_timer)
+		cooldown_timer = null
+	for(var/timer in duration_timers)
+		deltimer(timer)
+	duration_timers = null
+	discipline = null
+	owner = null
+	return ..()
+//TFN EDITT END - Harddels
+
 /**
  * Returns the time left the cooldown timer, or
  * 0 if there is none. Returning 0 means not on

--- a/modular_darkpack/modules/powers/code/discipline_actions.dm
+++ b/modular_darkpack/modules/powers/code/discipline_actions.dm
@@ -26,6 +26,38 @@
 
 	register_to_availability_signals()
 
+// TFN EDIT ADD - Harddels
+/datum/action/discipline/Destroy()
+	if(QDELETED(src))
+		return
+	if(owner)
+		UnregisterSignal(owner, COMSIG_QDELETING)
+	end_targeting()
+	if(owner)
+		UnregisterSignal(owner, list(
+			SIGNAL_ADDTRAIT(TRAIT_TORPOR),
+			SIGNAL_REMOVETRAIT(TRAIT_TORPOR),
+			SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT),
+			SIGNAL_REMOVETRAIT(TRAIT_KNOCKEDOUT),
+			SIGNAL_ADDTRAIT(TRAIT_INCAPACITATED),
+			SIGNAL_REMOVETRAIT(TRAIT_INCAPACITATED),
+			SIGNAL_ADDTRAIT(TRAIT_IMMOBILIZED),
+			SIGNAL_REMOVETRAIT(TRAIT_IMMOBILIZED),
+			SIGNAL_ADDTRAIT(TRAIT_FLOORED),
+			SIGNAL_REMOVETRAIT(TRAIT_FLOORED),
+			SIGNAL_ADDTRAIT(TRAIT_MUTE),
+			SIGNAL_REMOVETRAIT(TRAIT_MUTE),
+			SIGNAL_ADDTRAIT(TRAIT_HANDS_BLOCKED),
+			SIGNAL_REMOVETRAIT(TRAIT_HANDS_BLOCKED),
+			SIGNAL_ADDTRAIT(TRAIT_PACIFISM),
+			SIGNAL_REMOVETRAIT(TRAIT_PACIFISM),
+		))
+	if(discipline && !QDELETED(discipline))
+		qdel(discipline)
+	discipline = null
+	return ..()
+// TFN EDIT END - Harddels
+
 /datum/action/discipline/proc/register_to_availability_signals()
 	//this should only go through if it's the first Discipline gained by the mob
 	for (var/datum/action/action in owner.actions)


### PR DESCRIPTION
## About The Pull Request

trying to debug the bloodheal and dummy harddeletes.

basically just adding destroys that unregister signals, check if deletion is already taking place (since a recursive qdel loop is happening) and deletes references to subordinate datums (chain is /datum/action holds /datum/discipline, /datum/discipline holds /datum/discipline_power)

its happening on SPECIFICALLY bloodheal. i think it comes from humans holding actions that hold discipline that  hold discipline_power, but so do splats. i just added Destroy()s on parent types.

TM for now

## Why It's Good For The Game

lag

## Changelog



:cl:

code: trying to fix harddel lag
/:cl: