### PR TITLE
2 New Weapons for Cargo + Missing Weapon

### DIFF
--- a/modular_tfn/modules/cargo/code/supply_packs/weapons.dm
+++ b/modular_tfn/modules/cargo/code/supply_packs/weapons.dm
@@ -1,0 +1,20 @@
+/datum/supply_pack/weapons/weapondoubleshotgun
+	name = "Weapon (double barrel shotgun)"
+	desc = "Contains a double barrel shotgun."
+	cost = 1000
+	contains = list(/obj/item/gun/ballistic/shotgun/vampire/doublebarrel)
+	crate_name = "weapon crate"
+
+/datum/supply_pack/weapons/weaponcolt
+	name = "Weapon (colt m1911)"
+	desc = "Contains a Colt M1911."
+	cost = 250
+	contains = list(/obj/item/gun/ballistic/automatic/pistol/darkpack/m1911)
+	crate_name = "weapon crate"
+
+/datum/supply_pack/weapons/weaponlever
+	name = "Weapon (leveraction rifle)"
+	desc = "Contains a leveraction repeating rifle."
+	cost = 1600
+	contains = list(/obj/item/gun/ballistic/rifle/darkpack/lever)
+	crate_name = "weapon crate"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7783,6 +7783,7 @@
 #include "modular_darkpack\modules\z_travel\code\manhole.dm"
 #include "modular_darkpack\modules\z_travel\code\transfer_point.dm"
 #include "modular_tfn\master_files\code\modules\fishing\sources\subtypes\turfs.dm"
+#include "modular_tfn\modules\cargo\code\supply_packs\weapons.dm"
 #include "modular_tfn\modules\fishing\code\fishing.dm"
 #include "modular_tfn\modules\fishing\code\store_overrides.dm"
 #include "modular_tfn\modules\launch_clothing_update\code\suit.dm"


### PR DESCRIPTION

## About The Pull Request

Just adds the new lever action .44 and double barrel shotgun to the cargo system with their gunstore set prices (all the weapons in cargo use similar prices to those in the stores)

And added the missing M1911 that's in the gun store and all to the cargo system since it was forgotten.

<img width="385" height="365" alt="image" src="https://github.com/user-attachments/assets/cef6cd36-27e4-42a4-a3c8-0928079a8c45" />

## Why It's Good For The Game

Adds back in a missing gun that used to be in cargo + is in the gunstore back to cargo. Plus adds the two new weapons that were added to gunstore vendor to the cargo system as well.

## Changelog
:cl:
add: Adds lever action .44, double barrel shotgun, and .45 M1911 to cargo ordering
/:cl:
