### PR TITLE
Adds Art and Paper Supplies to the Library (again)

### DIFF
--- a/modular_darkpack/modules/retail/code/stores/library.dm
+++ b/modular_darkpack/modules/retail/code/stores/library.dm
@@ -1,6 +1,6 @@
 /obj/structure/retail/library
 	products_list = list(
-		new /datum/data/vending_product("black pen", /obj/item/pen, 5),
+		new /datum/data/vending_product("black pen", /obj/item/pen, 5), //TFN EDIT - START
 		new /datum/data/vending_product("folder", /obj/item/folder, 5),
 		new /datum/data/vending_product("four-color pen", /obj/item/pen/fourcolor, 10),
 		new /datum/data/vending_product("box of crayons", /obj/item/storage/crayons, 10),
@@ -16,5 +16,5 @@
 		new /datum/data/vending_product("Bible", /obj/item/book/bible, 20),
 		new /datum/data/vending_product("Quran", /obj/item/vampirebook/quran, 20),
 		new /datum/data/vending_product("spray paint", /obj/item/toy/crayon/spraycan, 25),
-		new /datum/data/vending_product("newspaper", /obj/item/newspaper, 5)
+		new /datum/data/vending_product("newspaper", /obj/item/newspaper, 5) //TFN EDIT - END
 	)


### PR DESCRIPTION
## About The Pull Request

Super quick thing to re-add the old paper and canvases and such, uncertain if I need to add the //TFN EDIT comments if I'll be PR'ing this to darkpack? Let me know if so!

## Why It's Good For The Game

Having access to art supplies is nice.

<img width="353" height="552" alt="image" src="https://github.com/user-attachments/assets/d95a9c48-4699-40d1-b4ca-71747b00dd96" />


## Changelog

:cl:
add: re-adds canvases and paper to the library shop
/:cl:

