### PR TITLE
mirror darkpack #939 'joining with negative freebie points is not allowed'

### DIFF
--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -166,6 +166,12 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 					tgui_alert(owner, "The server is full!", "Oh No!")
 					return TRUE
 
+			//DARKPACK EDIT ADD START - (prevents players from joining with negative freebie points)
+			var/datum/st_stat/freebie/freebie_stat = owner.client?.prefs?.preference_storyteller_stats[STAT_FREEBIE_POINTS]
+			if(freebie_stat && freebie_stat.points < 0)
+				tgui_alert(owner, "You cannot join with negative freebie points! Please fix your character preferences.", "Oh No!")
+				return TRUE
+			// DARKPACK EDIT ADD END
 			// SAFETY: AttemptLateSpawn has it's own sanity checks. This is perfectly safe.
 			owner.AttemptLateSpawn(params["job"])
 		if("viewpoll")

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -168,7 +168,7 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 
 			//DARKPACK EDIT ADD START - (prevents players from joining with negative freebie points)
 			var/datum/st_stat/freebie/freebie_stat = owner.client?.prefs?.preference_storyteller_stats[STAT_FREEBIE_POINTS]
-			if(freebie_stat && freebie_stat.points < 0)
+			if(freebie_stat && freebie_stat.get_points() < 0)
 				tgui_alert(owner, "You cannot join with negative freebie points! Please fix your character preferences.", "Oh No!")
 				return TRUE
 			// DARKPACK EDIT ADD END


### PR DESCRIPTION
## About The Pull Request

prevents joining with negative freebie points

<img width="1016" height="658" alt="dreamseeker_lPhU0yQMZZ" src="https://github.com/user-attachments/assets/9f01ef8e-99fd-45ee-8c94-add1e8a3ce7a" />
<img width="920" height="770" alt="kvJ9k1mJpb" src="https://github.com/user-attachments/assets/d48291be-9ddf-411a-8fc7-d7f9bd417929" />


## Why It's Good For The Game

preventing exploits

## Changelog

:cl:

fix: prevents joining the game with negative freebie points 

/:cl:

