### PR TITLE
ghoul fix

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline_pref_middleware.dm
+++ b/modular_darkpack/modules/powers/code/discipline_pref_middleware.dm
@@ -316,7 +316,8 @@ GLOBAL_LIST_INIT(rare_discipline_types, list(
 			var/discipline = text2path(disc_path)
 			if(!discipline)
 				continue
-			var/level = discipline_levels[disc_path]
+			var/level = character.get_splat(/datum/splat/vampire/ghoul) ? 1 : discipline_levels[disc_path] // TFN EDIT - cap ghouls at level 1 even if an admin gives them level 5
+
 			if(!level)
 				continue // prevent removing the disc by stopping here if they put 0 in it
 			var/result = character.change_st_power_level(discipline, level)

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -25,6 +25,7 @@
 
 /datum/splat/vampire/ghoul/on_gain()
 	owner.give_st_power(/datum/discipline/bloodheal, 1)
+	owner.give_st_power(/datum/discipline/potence, 1) // TFN EDIT ADD - ghoul fix
 
 	// the below only runs if they have just been ghouled and domitor isnt null
 	// ghouls who join from the menu have their discs handled by the disc pref middleware

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -38,3 +38,9 @@
 			owner.give_st_power(discipline, 1)
 			if(ispath(discipline, /datum/discipline/dementation))
 				owner.add_quirk(/datum/quirk/derangement)
+
+// TFN EDIT START
+/datum/splat/vampire/ghoul/on_lose_or_destroy()
+	owner.remove_st_power(/datum/discipline/bloodheal)
+	owner.remove_st_power(/datum/discipline/potence)
+// TFN EDIT END

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -37,6 +37,7 @@
 				continue
 			owner.give_st_power(discipline, 1)
 
+
 			if(ispath(discipline, /datum/discipline/dementation))
 				owner.add_quirk(/datum/quirk/derangement)
 

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -25,6 +25,7 @@
 
 /datum/splat/vampire/ghoul/on_gain()
 	owner.give_st_power(/datum/discipline/bloodheal, 1)
+	owner.give_st_power(/datum/discipline/potence, 1) // TFN EDIT ADD - potence 1 for ghoulies
 
 	// the below only runs if they have just been ghouled and domitor isnt null
 	// ghouls who join from the menu have their discs handled by the disc pref middleware

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -36,6 +36,7 @@
 			if(!discipline)
 				continue
 			owner.give_st_power(discipline, 1)
+
 			if(ispath(discipline, /datum/discipline/dementation))
 				owner.add_quirk(/datum/quirk/derangement)
 

--- a/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -25,7 +25,6 @@
 
 /datum/splat/vampire/ghoul/on_gain()
 	owner.give_st_power(/datum/discipline/bloodheal, 1)
-	owner.give_st_power(/datum/discipline/potence, 1) // TFN EDIT ADD - potence 1 for ghoulies
 
 	// the below only runs if they have just been ghouled and domitor isnt null
 	// ghouls who join from the menu have their discs handled by the disc pref middleware
@@ -36,13 +35,5 @@
 			if(!discipline)
 				continue
 			owner.give_st_power(discipline, 1)
-
-
 			if(ispath(discipline, /datum/discipline/dementation))
 				owner.add_quirk(/datum/quirk/derangement)
-
-// TFN EDIT START
-/datum/splat/vampire/ghoul/on_lose_or_destroy()
-	owner.remove_st_power(/datum/discipline/bloodheal)
-	owner.remove_st_power(/datum/discipline/potence)
-// TFN EDIT END

--- a/modular_tfn/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_tfn/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -1,7 +1,4 @@
 
-/datum/splat/vampire/ghoul/on_gain()
-	owner.give_st_power(/datum/discipline/potence, 1)
-
 /datum/splat/vampire/ghoul/on_lose_or_destroy()
 	owner.remove_st_power(/datum/discipline/bloodheal)
 	owner.remove_st_power(/datum/discipline/potence)

--- a/modular_tfn/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_tfn/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -1,0 +1,9 @@
+
+/datum/splat/vampire/ghoul/on_gain()
+	owner.give_st_power(/datum/discipline/potence, 1)
+
+
+/datum/splat/vampire/ghoul/on_lose_or_destroy()
+	owner.remove_st_power(/datum/discipline/bloodheal)
+	owner.remove_st_power(/datum/discipline/potence)
+

--- a/modular_tfn/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
+++ b/modular_tfn/modules/vampire_the_masquerade/code/splats/ghoul_splat/ghoul_splat.dm
@@ -2,7 +2,6 @@
 /datum/splat/vampire/ghoul/on_gain()
 	owner.give_st_power(/datum/discipline/potence, 1)
 
-
 /datum/splat/vampire/ghoul/on_lose_or_destroy()
 	owner.remove_st_power(/datum/discipline/bloodheal)
 	owner.remove_st_power(/datum/discipline/potence)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7833,6 +7833,8 @@
 #include "modular_tfn\modules\random_events\code\random_events.dm"
 #include "modular_tfn\modules\skillcheck\code\skillcheck.dm"
 #include "modular_tfn\modules\unit_tests\_tfn_unit_tests.dm"
+#include "modular_tfn\modules\vampire_the_masquerade\code\splats\ghoul_splat\ghoul_splat.dm"
 #include "modular_tfn\modules\vampire_the_masquerade\code\vampire_clan\trusted_whitelist.dm"
 #include "modular_tfn\modules\vampire_the_masquerade\code\vampire_clan\clans\lasombra\lasombra.dm"
+
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7836,5 +7836,4 @@
 #include "modular_tfn\modules\vampire_the_masquerade\code\splats\ghoul_splat\ghoul_splat.dm"
 #include "modular_tfn\modules\vampire_the_masquerade\code\vampire_clan\trusted_whitelist.dm"
 #include "modular_tfn\modules\vampire_the_masquerade\code\vampire_clan\clans\lasombra\lasombra.dm"
-
 // END_INCLUDE


### PR DESCRIPTION

## About The Pull Request

ghouls get pot and no longer can get adminbused disciplines above level 1

## Changelog
:cl:
add: Ghouls now get Potence 1 by default
fix: Ghouls can no longer get adminbused disciplines higher than level 1
/:cl:
