### PR TITLE
More Tower Employees

### DIFF
--- a/modular_darkpack/modules/jobs/code/camarilla/tower_employee.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/tower_employee.dm
@@ -1,8 +1,8 @@
 /datum/job/vampire/towerwork
 	title = JOB_TOWERWORK
 	faction = FACTION_CITY
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 7 //TFN EDIT 
+	spawn_positions = 7 //TFN EDIT
 	supervisors = SUPERVISOR_SENESCHAL_PUBLIC
 	exp_granted_type = EXP_TYPE_CAMARILLA
 	config_tag = "TOWER_EMPLOYEE"


### PR DESCRIPTION

## About The Pull Request
Just adds more Tower Employee slots.

## Why It's Good For The Game
The Camarilla is a big faction. Having seven hounds but only four normal employees seemed weird. So. Seven employees seems good!

## Changelog

:cl:
qol: transam is now hiring more employees, increased from 4-7
/:cl: