### PR TITLE
Makes Pentex Head of Security Garou only

### DIFF
--- a/modular_darkpack/modules/jobs/code/pentex/sec.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/sec.dm
@@ -3,8 +3,8 @@
 	description = "You are an acting security for " + MAIN_EVIL_COMPANY + ", operating out of San Francisco. Under the chief of security's direction, your job is to keep the complex free of nosy meddlers, pick up contract violators, and to assist the chief in tackling threats to corporate assets."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	faction = FACTION_CITY
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 4 // TFN EDIT CHANGE
+	spawn_positions = 4 // TFN EDIT CHANGE
 	supervisors = "the Board, Branch Lead, and Chief of Security"
 	req_admin_notify = 1
 	minimal_player_age = 25

--- a/modular_darkpack/modules/jobs/code/pentex/secchief.dm
+++ b/modular_darkpack/modules/jobs/code/pentex/secchief.dm
@@ -16,7 +16,7 @@
 	job_flags = CITY_JOB_FLAGS
 	outfit = /datum/outfit/job/vampire/secchief
 
-	allowed_splats = list(SPLAT_GAROU, SPLAT_KINDRED)
+	allowed_splats = list(SPLAT_GAROU) // TFN EDIT CHANGE
 //	allowed_tribes = list(TRIBE_WYRM, TRIBE_RONIN)
 	minimal_masquerade = 4
 


### PR DESCRIPTION

## About The Pull Request
Makes Pentex Head of Sec BSD and Ronin only. Also bumps Security Agents from 2 slots to 4 slots.
## Why It's Good For The Game
Head of Sec was BSD only in prebase. With this change, it makes it so only BSDs and Ronin can be in rebase. Kindred having access to the role with BSD and Ronin takes away the only Werewolf only role in Pentex. I think it's good for the corpo dogs to get a role that only they can pick. HoS is a middle management position as well which fits thematically. 

I set Sec Agent slots to 4 up from 2 because 2 is too little. It was 4 in prebase and that was fine. Having 4 allows a wider mix of werewolves, humans, kinfolk, and vampires to be on a sec team together and that's based as fuck.

Testing proof
<img width="378" height="108" alt="image" src="https://github.com/user-attachments/assets/393c5448-68aa-459f-b60d-0aeeef65f7be" />

## Changelog
:cl:
balance: Pentex HoS is BSD and Ronin only again.
balance: Security Agents now have 4 slots.
/:cl:
