### PR TITLE
Remove visibility check from visceratika discipline

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/visceratika.dm
+++ b/modular_darkpack/modules/powers/code/discipline/visceratika.dm
@@ -71,7 +71,7 @@
 	willpower_cost = 1
 
 	level = 2
-	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE 
+	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE  // TFN EDIT CHANGE - Original :  check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_SEE
 	toggled = TRUE
 	var/area/starting_area
 	var/datum/storyteller_roll/scry_the_hearthstone/scry_roll

--- a/modular_darkpack/modules/powers/code/discipline/visceratika.dm
+++ b/modular_darkpack/modules/powers/code/discipline/visceratika.dm
@@ -71,7 +71,7 @@
 	willpower_cost = 1
 
 	level = 2
-	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE  // TFN EDIT CHANGE - Original :  check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_SEE
+	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE  // TFN EDIT - Original :  check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_SEE
 	toggled = TRUE
 	var/area/starting_area
 	var/datum/storyteller_roll/scry_the_hearthstone/scry_roll

--- a/modular_darkpack/modules/powers/code/discipline/visceratika.dm
+++ b/modular_darkpack/modules/powers/code/discipline/visceratika.dm
@@ -71,7 +71,7 @@
 	willpower_cost = 1
 
 	level = 2
-	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_SEE
+	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE 
 	toggled = TRUE
 	var/area/starting_area
 	var/datum/storyteller_roll/scry_the_hearthstone/scry_roll


### PR DESCRIPTION
This is persuant to my funny complaint
I would enjoy blind gargoyle gimmicks.
## About The Pull Request
## Why It's Good For The Game

This would make it were blind gargoyles can commune with the building they are in, and detect people entering and exiting it. At least in theory.
I think it's balaced because you have to recast it each time you leave a building, so you can't just have it up the entire time, or you will run out of WP

## Changelog

Removes site check from viscrata
:c
