### PR TITLE
cqc feeding masq fix

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -236,6 +236,7 @@
 	if(old_grab_state == GRAB_PASSIVE)
 		defender.drop_all_held_items()
 		attacker.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab if on grab intent
+		defender.update_incapacitated() // TFN EDIT ADD - violation_check_aoe.dm checks for incapacitated to avoid masq reporting, so this is necessary or cqc knowing licks will get masq violations from the person being fed on
 		log_combat(attacker, defender, "grabbed", addition="aggressively")
 		defender.visible_message(
 			span_warning("[attacker] violently grabs [defender]!"),


### PR DESCRIPTION

## About The Pull Request
cqc grabs didnt update_incapacitated so npcs could freely report their biter when restrained with cqc. also, that means cqc was far less effective than it shouldve been in general

## Changelog
:cl:
fix: you will no longer get a masq violation by the person you feed on if you are cqc grabbing them
/:cl:
