### PR TITLE
HULK SMASH!! (Reduces jumper stun radius)

### DIFF
--- a/modular_darkpack/modules/jumping/code/jumper_component.dm
+++ b/modular_darkpack/modules/jumping/code/jumper_component.dm
@@ -145,7 +145,7 @@
 /datum/component/jumper/proc/jump_boom(mob/living/jumper)
 	playsound(get_turf(jumper), 'modular_darkpack/modules/jumping/sounds/jump_slam.ogg', 40, FALSE)
 	new /obj/effect/temp_visual/dir_setting/crack_effect(get_turf(jumper))
-	for(var/mob/living/shaken_person in range(5, jumper))
+	for(var/mob/living/shaken_person in range(2, jumper))	// TFN EDIT - JUMPER (5 -> 2)
 		if(shaken_person == jumper)
 			continue
 		shaken_person.Stun(20)


### PR DESCRIPTION

## About The Pull Request

Takes the 8+ strength jump effect that had a 5 tile stun radius with 20 tick stun (~2 seconds) and makes it into a 2 tile radius.

Before someone would jump on your screen and cause a disarm of everyone in a 5 tile radius, causing annoying issues of spam-jumping or such. 

## Why It's Good For The Game

Most people seem to agree it's really annoying, especially since Garou get it with 8 strength, anyone w/ potence 3, and artifacts even let you do it if you amass strength ones enough. Causes really annoying stun-fights where they get a free stun and disarm for just jumping at you which can result in near instant death.

## Changelog
:cl:
balance: Reduces jumper ground-pound range from 5 to 2. Get closer.
/:cl:
