### PR TITLE
Protean 2 Damage Fix

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/protean/claws.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/claws.dm
@@ -20,4 +20,9 @@
 /obj/item/gangrel_claws/pre_attack(atom/target, mob/living/user, list/modifiers, list/attack_modifiers)
 	. = ..()
 	// Based on V20
+	/* TFN EDIT REMOVAL - Protean 2 Damage Fix
+	if(isliving(user))
+		var/mob/living/living_user = user
+		force = (living_user.st_get_stat(STAT_STRENGTH) + 1) TTRPG_DAMAGE
+	*/
 	force = ((user.st_get_stat (STAT_STRENGTH) + 1) * 5)

--- a/modular_darkpack/modules/powers/code/discipline/protean/claws.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/claws.dm
@@ -25,4 +25,4 @@
 		var/mob/living/living_user = user
 		force = (living_user.st_get_stat(STAT_STRENGTH) + 1) TTRPG_DAMAGE
 	*/
-	force = ((user.st_get_stat (STAT_STRENGTH) + 1) * 5)
+	force = ((user.st_get_stat (STAT_STRENGTH) + 1) * 5) // TFN EDIT ADD - Protean 2 Damage Fix

--- a/modular_darkpack/modules/powers/code/discipline/protean/claws.dm
+++ b/modular_darkpack/modules/powers/code/discipline/protean/claws.dm
@@ -20,6 +20,4 @@
 /obj/item/gangrel_claws/pre_attack(atom/target, mob/living/user, list/modifiers, list/attack_modifiers)
 	. = ..()
 	// Based on V20
-	if(isliving(user))
-		var/mob/living/living_user = user
-		force = (living_user.st_get_stat(STAT_STRENGTH) + 1) TTRPG_DAMAGE
+	force = ((user.st_get_stat (STAT_STRENGTH) + 1) * 5)


### PR DESCRIPTION

## About The Pull Request

Fixes Protean 2 so it no longer puts a victim into crit from 2 swipes regardless of the users strength.

## Why It's Good For The Game

In game we have been plagued with people using protean 2 to kill people in 2 hits with protean 2 and cause wounds that are extremely difficult to heal, especially for mortal characters. This makes the time to kill with protean claws much fairer by halving the damage it gives to victims of the claws.

## Changelog
:cl:
balance: Changed protean 2 claws to halve the damage they give to victims.
:cl:
