### PR TITLE
you can now carry more money

### DIFF
--- a/modular_darkpack/modules/economy/code/dollar.dm
+++ b/modular_darkpack/modules/economy/code/dollar.dm
@@ -9,7 +9,8 @@
 	ONFLOOR_ICON_HELPER('modular_darkpack/modules/deprecated/icons/onfloor.dmi')
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
-	max_amount = 1000
+	full_w_class = WEIGHT_CLASS_SMALL // TFN EDIT ADD
+	max_amount = 10000 // TFN EDIT CHANGE - ORIGINAL: 1000
 	merge_type = /obj/item/stack/dollar
 
 /obj/item/stack/dollar/Initialize(mapload, new_amount, merge = TRUE, list/mat_override = null, mat_amt = 1)


### PR DESCRIPTION

## About The Pull Request
ups stack size to 10,000 instead of 1,000, and adjusts the max weight size so they can be stored in wallets easier

## Changelog
:cl:
refactor: you can now carry more than 1,000 dollars and store it in wallets
/:cl:
