### PR TITLE
fixes auspexers being able to speak, auspex 3 countering auspex 5

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/auspex/avatar/avatar.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/avatar/avatar.dm
@@ -77,6 +77,6 @@
 
 // TFN EDIT START
 /mob/living/basic/avatar/try_speak(message, ignore_spam, forced, filterproof)
-	to_chat(src, span_warning("You cannot speak while auspexing."))
+	to_chat(src, span_warning("You cannot speak while astrally projecting!"))
 	return FALSE
 // TFN EDIT END

--- a/modular_darkpack/modules/powers/code/discipline/auspex/avatar/avatar.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/avatar/avatar.dm
@@ -74,3 +74,9 @@
 	var/known_name = GET_GUESTBOOK_NAME(src, hovered)
 	returned_name[1] = known_name ? "[known_name]" : "[hovered.name]"
 	return SCREENTIP_NAME_SET
+
+// TFN EDIT START
+/mob/living/basic/avatar/try_speak(message, ignore_spam, forced, filterproof)
+	to_chat(src, span_warning("You cannot speak while auspexing."))
+	return FALSE
+// TFN EDIT END

--- a/modular_darkpack/modules/powers/code/discipline/auspex/avatar/mob_procs.dm
+++ b/modular_darkpack/modules/powers/code/discipline/auspex/avatar/mob_procs.dm
@@ -9,3 +9,7 @@
 	SStgui.on_transfer(src, ghost) // Transfer NanoUIs.
 	ghost.PossessByPlayer(key)
 	ghost.client?.init_verbs()
+	// TFN EDIT START
+	ghost.set_hud_image_inactive(HEALTH_HUD)
+	ghost.set_hud_image_inactive(STATUS_HUD)
+	// TFN EDIT END


### PR DESCRIPTION

## About The Pull Request

auspex avatars can no longer speak nor be seen with auspex 3

## Changelog
:cl:
fix: auspex 5 no longer allows the user to speak while in avatar form or be seen by auspex 3
/:cl:
