### PR TITLE
Gives Malk Speech to anyone with Derangement

### DIFF
--- a/modular_tfn/modules/merits_flaws/code/negative_quirks/derangement_nonmalk.dm
+++ b/modular_tfn/modules/merits_flaws/code/negative_quirks/derangement_nonmalk.dm
@@ -2,3 +2,7 @@
 	darkpack_allowed = TRUE
 	excluded_clans = list(VAMPIRE_CLAN_MALKAVIAN, VAMPIRE_CLAN_DOMINATE_MALKAVIAN)
 	value = -3
+
+/datum/quirk/darkpack/derangement/nonmalk/post_add()
+	var/datum/action/cooldown/malk_speech/malk_font = new(quirk_holder)
+	malk_font.Grant(quirk_holder)


### PR DESCRIPTION

## About The Pull Request
Ties Malk_Speech to Derangement instead of the Malk Clan.
## Why It's Good For The Game
Malk speech is a VTM:Bism and isn't a lore thing. Adding it to anyone with derangement lets more people play with it, while also making the madness speech less able to meta malks with. 

I tested this trust me Buffy saw me do it.
## Changelog
:cl:
balance: Anyone Derangement gets Malk Speech now
/:cl:
