### PR TITLE
organs no longer decay inside of you

### DIFF
--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -163,7 +163,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	if(owner)
 		if(owner.bodytemperature > T0C)
 			var/air_temperature_factor = min((owner.bodytemperature - T0C) / 20, 1)
-			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
+			//apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor) // TFN REMOVAL - organs should only decay when exposed to the air, not when they are inside of someone
 	else
 		var/datum/gas_mixture/exposed_air = return_air()
 		if(exposed_air && exposed_air.temperature > T0C)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -162,8 +162,13 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 	if(owner)
 		if(owner.bodytemperature > T0C)
+			return
+			// TFN REMOVAL START - organs should only decay when exposed to the air, not when they are inside of someone
+			/*
 			var/air_temperature_factor = min((owner.bodytemperature - T0C) / 20, 1)
-			//apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor) // TFN REMOVAL - organs should only decay when exposed to the air, not when they are inside of someone
+			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
+			*/
+			// TFN REMOVAL END
 	else
 		var/datum/gas_mixture/exposed_air = return_air()
 		if(exposed_air && exposed_air.temperature > T0C)


### PR DESCRIPTION

## About The Pull Request

changes organs to only 'rot' (aka utilize decay_factor) when not inside of a mob, to prevent the need for EMTs to awkwardly perform heart surgery

## Changelog
:cl:
refactor: Organs no longer rot inside of bodies after they die, only when exposed to the open air
/:cl:
