### PR TITLE
Mirror upstream fix

### DIFF
--- a/modular_darkpack/modules/electricity/code/fusebox.dm
+++ b/modular_darkpack/modules/electricity/code/fusebox.dm
@@ -101,7 +101,7 @@ GLOBAL_LIST_EMPTY(fuseboxes)
 				return ITEM_INTERACT_SUCCESS
 			if(repair_amount <= 0)
 				user.electrocute_act(50, src, siemens_coeff = 1, flags = NONE)
-
+				repairing = FALSE
 	return NONE
 
 // transformers (another type of fusebox)


### PR DESCRIPTION

## About The Pull Request
mirror of https://github.com/DarkPack13/SecondCity/pull/1045
:cl:
fix: Fixed transformers being unfixable upon failing the roll
:cl:
