### PR TITLE
FIX #291 (Forgot to include it in tgstation.dme)

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7922,6 +7922,7 @@
 #include "modular_tfn\modules\blooper\code\preferences\preferences.dm"
 #include "modular_tfn\modules\blooper\code\preferences\middleware\blooper.dm"
 #include "modular_tfn\modules\cargo\code\supply_packs\humans.dm"
+#include "modular_tfn\modules\cargo\code\supply_packs\medical.dm"
 #include "modular_tfn\modules\cargo\code\supply_packs\weapons.dm"
 #include "modular_tfn\modules\cars\code\subtypes.dm"
 #include "modular_tfn\modules\casino\casino.dm"


### PR DESCRIPTION

## About The Pull Request

Fixes an issue with my previous pull request so that the DIY Chemistry Kit actually shows up on the express console now.
## Why It's Good For The Game

In my hubris, my greed, my laziness, possessed by the demons of sloth and pride all at the same time.. I did not think my pull request required testing due to it being a "simple" change. I was technically right about the change being simple, but unfortunately I am too.

Please forgib me and merge when you can. Love ya.

PS: yes I tested it this time.
## Changelog
:cl:
fix: included the missing DIY Chemistry Crate in tgstation.dme (Relates to #291)
/:cl:
