### PR TITLE
Presence BP cost fix

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/presence/presence.dm
+++ b/modular_darkpack/modules/powers/code/discipline/presence/presence.dm
@@ -148,7 +148,6 @@
 	multi_activate = TRUE
 	cooldown_length = 15 SECONDS
 	duration_length = 10 SECONDS
-	vitae_cost = 1 //no mention of literally any cost for using this in V20
 	var/successes = 0
 
 


### PR DESCRIPTION

## About The Pull Request

Presence 2 has duplicated vitae costs, one the correct 0, the an incorrect 1, leading to it costing 1 BP. This fixes that issue.

## Why It's Good For The Game

Fixing error.

## Changelog

:cl:
fix: Fixed incorrect BP cost for Presence 2
/:cl:
