### PR TITLE
Potence Cost Adjustment

### DIFF
--- a/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
+++ b/modular_darkpack/modules/powers/code/discipline/potence/potence.dm
@@ -20,7 +20,7 @@
 	check_flags = DISC_CHECK_CAPABLE
 
 	toggled = TRUE
-	duration_length = 1 TURNS
+	duration_length = 2 TURNS	//TFN EDIT - Swapped from 1 turn duration back to 2 after discussion
 
 /datum/discipline_power/potence/post_gain()
 	owner.st_add_stat_mod(STAT_STRENGTH, level, "Potence")


### PR DESCRIPTION

## About The Pull Request

I did an upstream attempt of this but was suggested by a few people based on feedback to just reset the cost to 2 turns.
https://github.com/DarkPack13/SecondCity/pull/1061

Reason why is simple - TT has potence do this for all rolls on a turn. Issue is that due to the game being real-time, people do not move in a turn based order nor can you reeeaaally get off multiple hits with potence in most combat cases in a single turn cycle in game right now. Similarly, a door bash takes longer than the potence even lasts for.

That alongside its drain being 2x the cost of other active abilities currently (TT accurate or not) causes it to really feel lacking in a lot of cases despite the actual cool use of the auto-success dice. Just gets instantly out-paced by celerity due to having double the BP consumption.

## Why It's Good For The Game

This just returns potence to its prior duration but with the newer, better ability from upstream. It should make potence stand on two feet as a combat discipline akin to celerity and fortitude rather than draining at 2x the rate of those abilities. 

## Changelog
:cl:
balance: Resets potence duration to 2 turns instead of 1.
/:cl:
