### PR TITLE
SALT ALERT: CASINO REBALANCE.

### DIFF
--- a/modular_tfn/modules/casino/casino.dm
+++ b/modular_tfn/modules/casino/casino.dm
@@ -149,19 +149,8 @@
 			if("cherry")
 				payout_multiplier = cherry_payout
 
-
-// TFN Edit: Pairs will now return your bet instead of doubling it to avoid massive player favoured advantage.
 	else if(reelone == reeltwo || reelone == reelthree || reeltwo == reelthree)
 		payout_multiplier = 1 // any pair pays 1x the bet
-
-// TFN Removal: Removing ridiculous fucking mechanics that contributed to the return to player percentage exceeding 200%.
-/* TFN REMOVAL START
-
-	for(var/symbol in reels)
-		if(symbol == "diamond")
-			payout_multiplier *= 2 // each diamond multiplies payout by 2
-
-TFN REMOVAL END */
 
 	return CEILING(payout_multiplier, 1) // round up just incase
 

--- a/modular_tfn/modules/casino/casino.dm
+++ b/modular_tfn/modules/casino/casino.dm
@@ -20,9 +20,9 @@
 
 	// dice rolls for each symbol
 	var/sevenroll = 5
-	var/diamondroll = 5
-	var/bellroll = 15
-	var/barroll = 25
+	var/diamondroll = 16
+	var/bellroll = 34
+	var/barroll = 58
 
 	// payouts for each symbol based on the result
 	var/seven_payout = 77
@@ -57,16 +57,16 @@
 	desc = "Higher stakes, higher rewards!"
 	// dice rolls for each symbol
 	sevenroll = 5
-	diamondroll = 5
-	bellroll = 15
-	barroll = 20
+	diamondroll = 16
+	bellroll = 34
+	barroll = 58
 
 	// payouts for each symbol based on the result
 	seven_payout = 77
-	diamond_payout = 30
-	bell_payout = 15
-	bar_payout = 10
-	cherry_payout = 6
+	diamond_payout = 25
+	bell_payout = 10
+	bar_payout = 5
+	cherry_payout = 3
 
 	// bet sizes
 	bet_size = 25
@@ -111,7 +111,7 @@
 	list("symbols" = list("bell",    "bell",    "bell"),    "payout" = bell_payout),
 	list("symbols" = list("bar",     "bar",     "bar"),     "payout" = bar_payout),
 	list("symbols" = list("cherry",  "cherry",  "cherry"),  "payout" = cherry_payout),
-	list("symbols" = list(null,      null,      null),      "payout" = 2, "pair" = TRUE)
+	list("symbols" = list(null,      null,      null),      "payout" = 1, "pair" = TRUE)
 	)
 
 	return data
@@ -148,12 +148,20 @@
 				payout_multiplier = bar_payout
 			if("cherry")
 				payout_multiplier = cherry_payout
+
+
+// TFN Edit: Pairs will now return your bet instead of doubling it to avoid massive player favoured advantage.
 	else if(reelone == reeltwo || reelone == reelthree || reeltwo == reelthree)
-		payout_multiplier = 2 // any pair pays 2x the bet
+		payout_multiplier = 1 // any pair pays 1x the bet
+
+// TFN Removal: Removing ridiculous fucking mechanics that contributed to the return to player percentage exceeding 200%.
+/* TFN REMOVAL START
 
 	for(var/symbol in reels)
 		if(symbol == "diamond")
 			payout_multiplier *= 2 // each diamond multiplies payout by 2
+
+TFN REMOVAL END */
 
 	return CEILING(payout_multiplier, 1) // round up just incase
 

--- a/tgui/packages/tgui/interfaces/TFNSlotMachine.jsx
+++ b/tgui/packages/tgui/interfaces/TFNSlotMachine.jsx
@@ -265,7 +265,9 @@ export const TFNSlotMachine = () => {
               <Paysymbols key={i} entry={entry} />
             ))}
             {[
+            /* TFN EDIT REMOVAL START - Slots rebalanced
               ['💎', 'x2 per'],
+            TFN EDIT REMOVAL END */
               ['Payouts are bet x multiplier', ''],
             ].map(([label, value], i) => (
               <Box


### PR DESCRIPTION

## About The Pull Request

**YES I TESTED IT. IT WORKS.**

This rebalances the casino by removing the fucking insane "2x multiplier per diamond" and rebalances the payouts and roll ranges so that the average Return To Player (RTP) value will be 95% which is more in line what IRL slot machines have.

1x Cherry: 42%  3x Cherries: 7.41%  RTP Value: 22.23%
1x Bar: 24%.  3x Bars: 1.38%. RTP Value: 6.91%
1x Bell: 18%. 3x Bars: 0.58%. RTP Value: 5.83%
1x Diamond: 11%. 3x Diamonds: 0.13%. RTP Value: 3.33%
1x Seven: 5%. 3x Seven: 0.013%. RTP Value: 0.96%

Any Pair: 55.74% (same as the RTP value).

Total RTP: 95% Returned to player on average.
## Why It's Good For The Game

Diamonds would never show because Diamond and Sevens both had the same roll value assigned to them, but it would check seven first. Since Cherry didn't actually have a value assigned to it, just a "if roll isn't <= any of the other symbol roll values, return cherry", it meant that Cherries had a 75% chance of landing on the standard machine, and an 80% chance of landing on the deluxe machine (due to random roll differences between the two machines).

RTP calculation is basically: Probability of outcome * the payout. Anything above 100% means the machine is consistently profitable for the player on average and the house is bleeding money.


**Standard Machine:**
This meant that you had a 42.19% chance of getting 3x cherries in a row on the standard machine, meaning every third spin you were basically guaranteed +26.56% of your bet. (an average RTP value of 126.56% alone just from these damn 3-in-a-row cherries!!)

But ontop of that, the chance of hitting a pair of cherries has the same chance as hitting three cherries except it pays out double the bet instead of triple. 42.19% x 2 = 84.38% RTP contribution.

The other 3x and pair outcomes contributed an RTP of 14.69%. Altogether, the standard machine would pay out to the player **225.62% than what they put in.** 

**The Deluxe Machine**

This is where it gets fucked: Cherry probability is 80% per reel due to differences in the bar/bell symbol values. 3x Cherries hit 51.2% of the time, Cherry pairs hit 38.4% of the time and ONTOP OF THAT, it pays 6x your bet for cherries instead of 3x!!! (wtf?)

3x Cherries RTP: 51.2% x 6 = 307.20% RTP
2x Cherries RTP: 38.4% x 2 = 76.80% RTP
Other triple/pair outcomes total RTP contribution: 10.84%

Total RTP contribution: **394.84%!!!!!!!!!!!!!!!!!!** (PERPETUALLY 4xing YOUR MONEY FOREVER)

**The 2x multiplier per diamond and 2x for each pair rules are broken as fuck**

To avoid more word wall salad I'm not going to continue spamming calculations, but just know that both these rules, together and individually (by only removing one or the other), would lead to the RTP being well over 100%, so there was really no way to keep them.

Now these probabilities have been corrected and the payouts modified to be the same, players will on average lose 5% of their starting bankroll long-term, rather than quadrupling it. Which is how slots actually tend to work.
## Changelog
:cl:
del: Removed the 2x per diamond rule on the casino slot machines.
balance: Changed the probabilities and payouts for the slot machines so that they are no longer money printers.
balance: The "Any pair" slot machine payout now only refunds your bet instead of doubling it.
/:cl:
