### PR TITLE
Gives Trujah Keys to Stop being Falsejah

### DIFF
--- a/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/true_brujah.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/true_brujah.dm
@@ -15,3 +15,5 @@
 	female_clothes = /obj/item/clothing/under/vampire/business
 	restricted_disciplines = list(/datum/discipline/celerity)
 	whitelisted = TRUE
+
+	subsplat_keys = /obj/item/vamp/keys/brujah	//TFN EDIT ADD - TRUJAH KEYS


### PR DESCRIPTION

## About The Pull Request

Gave Trujah the Brujah clan keys, lets them mingle with Brujah given they literally pose as Brujah. Makes sense they'd at least schmooze some with other falsejah clan members to try and properly blend in.

## Why It's Good For The Game

Fits a bit with Trujah lore and lets the Trujah we have that all pose as Brujah actually attend Brujah meetings and mingle with Brujah. 

They are intertwined and should be fine.

## Changelog
:cl:
add: Gives Trujah Brujah keys.
/:cl:
