### PR TITLE
Allows for the katana to be used in the burning blade ritual via the unused KJ egorium icon state + Small bugfix.

### DIFF
--- a/modular_darkpack/modules/ritual_thaumaturgy/rituals/burning_blade.dm
+++ b/modular_darkpack/modules/ritual_thaumaturgy/rituals/burning_blade.dm
@@ -6,8 +6,6 @@
 	level = 2
 	cost = 3
 
-// TFN EDIT ADD START - Adds the fire katana to the burning blade ritual.
-
 /obj/ritual_rune/thaumaturgy/burning_blade/complete()
 	. = ..()
 	var/obj/item/scythe/vamp/scythe = locate(/obj/item/scythe/vamp) in get_turf(src)
@@ -23,11 +21,11 @@
 	to_chat(last_activator, span_notice("The [weapon.name] ignites with an unholy flame for [charges] swings!"))
 	qdel(src)
 
-//Turns a scythe into the 'egorium' icon state, allowing tremeres to deal aggravated damage for a few swings.
+// Turns a scythe/katana into the 'egorium' icon state, allowing tremeres to deal aggravated damage for a few swings.
 /datum/component/burning_blade
 	var/original_damtype
 	var/original_icon_state
-	var/original_inhand_icon_state  // TFN EDIT CHANGE: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
+	var/original_inhand_icon_state
 	var/charges
 
 /datum/component/burning_blade/Initialize(charges)
@@ -38,7 +36,7 @@
 	src.charges = charges
 	original_damtype = weapon.damtype
 	original_icon_state = weapon.icon_state
-	original_inhand_icon_state = weapon.inhand_icon_state  // TFN EDIT CHANGE: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
+	original_inhand_icon_state = weapon.inhand_icon_state  
 	weapon.damtype = AGGRAVATED
 
 	if(istype(weapon, /obj/item/katana/vamp))
@@ -59,9 +57,7 @@
 	var/obj/item/weapon = parent
 	weapon.damtype = original_damtype
 	weapon.icon_state = original_icon_state
-	weapon.inhand_icon_state = original_inhand_icon_state // TFN EDIT CHANGE: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
-
-// TFN EDIT ADD END - Adds the fire katana to the burning blade ritual.
+	weapon.inhand_icon_state = original_inhand_icon_state 
 
 /datum/component/burning_blade/proc/on_hit_living()
 	SIGNAL_HANDLER

--- a/modular_darkpack/modules/ritual_thaumaturgy/rituals/burning_blade.dm
+++ b/modular_darkpack/modules/ritual_thaumaturgy/rituals/burning_blade.dm
@@ -9,22 +9,23 @@
 /obj/ritual_rune/thaumaturgy/burning_blade/complete()
 	. = ..()
 	var/obj/item/scythe/vamp/scythe = locate(/obj/item/scythe/vamp) in get_turf(src)
-	if(!scythe)
-		to_chat(last_activator, span_warning("You need a scythe to enchant!"))
+	var/obj/item/katana/vamp/katana = locate(/obj/item/katana/vamp) in get_turf(src)
+	var/obj/item/weapon = scythe || katana
+	if(!weapon)
+		to_chat(last_activator, span_warning("You need a scythe or katana to enchant!"))
 		return
-
 	if(!ritual_roll_datum)
 		return
-
 	var/charges = ritual_roll_datum.last_sucess_amount
-	scythe.AddComponent(/datum/component/burning_blade, charges)
-	to_chat(last_activator, span_notice("The scythe ignites with an unholy flame for [charges] swings!"))
+	weapon.AddComponent(/datum/component/burning_blade, charges)
+	to_chat(last_activator, span_notice("The [weapon.name] ignites with an unholy flame for [charges] swings!"))
 	qdel(src)
 
 //Turns a scythe into the 'egorium' icon state, allowing tremeres to deal aggravated damage for a few swings.
 /datum/component/burning_blade
 	var/original_damtype
 	var/original_icon_state
+	var/original_inhand_icon_state  // bugfix: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
 	var/charges
 
 /datum/component/burning_blade/Initialize(charges)
@@ -35,9 +36,15 @@
 	src.charges = charges
 	original_damtype = weapon.damtype
 	original_icon_state = weapon.icon_state
+	original_inhand_icon_state = weapon.inhand_icon_state  // bugfix: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
 	weapon.damtype = AGGRAVATED
-	weapon.icon_state = "egorium"
-	weapon.inhand_icon_state = "egorium"
+
+	if(istype(weapon, /obj/item/katana/vamp))
+		weapon.icon_state = "firetana"
+		weapon.inhand_icon_state = "firetana"
+	else
+		weapon.icon_state = "egorium"
+		weapon.inhand_icon_state = "egorium"
 
 	return ..()
 
@@ -50,7 +57,7 @@
 	var/obj/item/weapon = parent
 	weapon.damtype = original_damtype
 	weapon.icon_state = original_icon_state
-	weapon.inhand_icon_state = original_icon_state
+	weapon.inhand_icon_state = original_inhand_icon_state
 
 /datum/component/burning_blade/proc/on_hit_living()
 	SIGNAL_HANDLER

--- a/modular_darkpack/modules/ritual_thaumaturgy/rituals/burning_blade.dm
+++ b/modular_darkpack/modules/ritual_thaumaturgy/rituals/burning_blade.dm
@@ -6,6 +6,8 @@
 	level = 2
 	cost = 3
 
+// TFN EDIT ADD START - Adds the fire katana to the burning blade ritual.
+
 /obj/ritual_rune/thaumaturgy/burning_blade/complete()
 	. = ..()
 	var/obj/item/scythe/vamp/scythe = locate(/obj/item/scythe/vamp) in get_turf(src)
@@ -25,7 +27,7 @@
 /datum/component/burning_blade
 	var/original_damtype
 	var/original_icon_state
-	var/original_inhand_icon_state  // bugfix: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
+	var/original_inhand_icon_state  // TFN EDIT CHANGE: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
 	var/charges
 
 /datum/component/burning_blade/Initialize(charges)
@@ -36,7 +38,7 @@
 	src.charges = charges
 	original_damtype = weapon.damtype
 	original_icon_state = weapon.icon_state
-	original_inhand_icon_state = weapon.inhand_icon_state  // bugfix: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
+	original_inhand_icon_state = weapon.inhand_icon_state  // TFN EDIT CHANGE: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
 	weapon.damtype = AGGRAVATED
 
 	if(istype(weapon, /obj/item/katana/vamp))
@@ -57,7 +59,9 @@
 	var/obj/item/weapon = parent
 	weapon.damtype = original_damtype
 	weapon.icon_state = original_icon_state
-	weapon.inhand_icon_state = original_inhand_icon_state
+	weapon.inhand_icon_state = original_inhand_icon_state // TFN EDIT CHANGE: the original inhand_icon_state is now stored separately to ensure it's returned to the correct sprite.
+
+// TFN EDIT ADD END - Adds the fire katana to the burning blade ritual.
 
 /datum/component/burning_blade/proc/on_hit_living()
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

Allows the burning blade ritual to be used on the katana, making use of the unused KJ sprite (supposedly there is no intention of it being used on the rebase). 

Also fixes a small bug where the original inhand_icon_state isn't saved separately before it's later restored to original_icon_state, could've caused issues if the icon_state and in_hand_icon state were different before the component is applied.
## Why It's Good For The Game

Makes use of a sprite that would otherwise be wasted, opens up more functionality for the burning blade ritual, potentially allowing tremere to ignite the swords of others and not just themselves. Hopefully one day we can get more firey sword sprites so it can be used on any sword.

Also hopefully will let us have a weapon that we can set on fire which can actually be concealed within a bag rather than having a giant-ass unconcealable scythe on our back 24/7. (although upon making this I have discovered the katana is not sheathable, so I might need to look into this via a separate PR...)
## Changelog
:cl:
add: Added the katana as one of the blade options for the Burning Blade ritual.
fix: saves the inhand_icon_state before restoring to original_icon_state to avoid the wrong sprite being used.
/:cl:
