### PR TITLE
Dragons breath price change

### DIFF
--- a/modular_darkpack/modules/cargo/code/supply_packs/weapons.dm
+++ b/modular_darkpack/modules/cargo/code/supply_packs/weapons.dm
@@ -230,7 +230,7 @@
 /datum/supply_pack/weapons/ammo12g/incendiary
 	name = "Ammo (12g, Dragon's Breath)"
 	desc = "Contains a box of 12g incendiary shells."
-	cost = 4000
+	cost = 12000
 	contains = list(/obj/item/ammo_box/darkpack/c12g/buck/incendiary)
 	crate_name = "ammo crate"
 


### PR DESCRIPTION

## About The Pull Request

Increases price of dragons breath ammo from $4000 to $12000.

## Why It's Good For The Game

It's been noticed that many players in game have started to carry and load dragons breath by default very close to the start of the round. While this does break the rules, some players have persisted nonetheless, creating incidents where people have been round removed abruptly due to players over escalating by carrying dragons breath by default.

## Changelog

:cl:
balance: Increases the price of dragons breath from $4000 to $12000.
:cl:
<img width="362" height="42" alt="image" src="https://github.com/user-attachments/assets/ef538988-8115-47db-a656-6d53b0e27ace" />
