### PR TITLE
Humanity 10 not immune to sun

### DIFF
--- a/modular_darkpack/modules/city_time/code/status_effects.dm
+++ b/modular_darkpack/modules/city_time/code/status_effects.dm
@@ -28,8 +28,8 @@
 	if(!kindred_owner)
 		return FALSE
 	// Humanity 10 vamps are immume to the light. atleast for the amount of time our day lasts.
-	if(CONFIG_GET(flag/humanity_sunlight_resistance) && !owner.is_enlightenment() && (owner.st_get_stat(STAT_MORALITY) >= 10))
-		return FALSE
+	// if(CONFIG_GET(flag/humanity_sunlight_resistance) && !owner.is_enlightenment() && (owner.st_get_stat(STAT_MORALITY) >= 10)) // TFN EDIT REMOVAL - Humanity 10 Not Immune to Sun
+		// return FALSE // TFN EDIT REMOVAL - Humanity 10 Not Immune to Sun
 
 	to_chat(owner, span_danger("THE SUN SEARS YOUR FLESH"))
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
Kindred with Humanity 10 are no longer immune to the sun. 

Proof ig
<img width="643" height="128" alt="Screenshot 2026-06-24 003124" src="https://github.com/user-attachments/assets/a2f67868-d2bf-4e7d-ba06-009c0ff0f8f7" />

## Why It's Good For The Game
It's not lore accurate and doesn't make sense. It's also an old code holdover. 
## Changelog
:cl:
del: Removed the ability for Humanity 10 kindred to daywalk.
/:cl:
