### PR TITLE
The Gaians can have some ranger access as a treat

### DIFF
--- a/_maps/map_files/Vampire/sanfrancisco/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/sanfrancisco/SanFrancisco.dmm
@@ -16464,11 +16464,11 @@
 	},
 /area/vtm/interior/nosferatu_office)
 "ead" = (
-/obj/effect/mapping_helpers/door/access/park_ranger,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
 /obj/structure/vampdoor/wood{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/door/access/evergreen,
 /turf/open/floor/wood/rough,
 /area/vtm/interior/ranger)
 "eae" = (


### PR DESCRIPTION

## About The Pull Request
Gives the Ranger tower the Nature's bounty helper so the gaian keys can open it. 

Proof I guesssss
<img width="672" height="621" alt="image" src="https://github.com/user-attachments/assets/f5e346c8-2b9e-489b-b2ca-baf133e0fa5e" />
## Why It's Good For The Game
Lets the Gaians more effectively LARP as park rangers cause they have like no other content right now and no one else owns the tower so sure, why not. 
## Changelog
:cl:
balance: Ranger Tower uses Nature's Bounty Helper
/:cl:
