### PR TITLE
Removes Defunct Keys and Gives Relevant Keys for some Splats

### DIFF
--- a/modular_darkpack/modules/jobs/code/giovanni/la_squadra.dm
+++ b/modular_darkpack/modules/jobs/code/giovanni/la_squadra.dm
@@ -28,7 +28,7 @@
 	suit = /obj/item/clothing/suit/vampire/trench
 	shoes = /obj/item/clothing/shoes/vampire
 	l_pocket = /obj/item/smartphone/giovanni_squadra
-	//r_pocket = /obj/item/vamp/keys/giovanni //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
+	r_pocket = /obj/item/vamp/keys/giovanni
 	backpack_contents = list(/obj/item/card/credit/rich=1, /obj/item/ritual_tome/necromancy=1)
 
 

--- a/modular_darkpack/modules/jobs/code/giovanni/la_squadra.dm
+++ b/modular_darkpack/modules/jobs/code/giovanni/la_squadra.dm
@@ -28,7 +28,7 @@
 	suit = /obj/item/clothing/suit/vampire/trench
 	shoes = /obj/item/clothing/shoes/vampire
 	l_pocket = /obj/item/smartphone/giovanni_squadra
-	r_pocket = /obj/item/vamp/keys/giovanni
+	//r_pocket = /obj/item/vamp/keys/giovanni //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 	backpack_contents = list(/obj/item/card/credit/rich=1, /obj/item/ritual_tome/necromancy=1)
 
 

--- a/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/doc.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/doc.dm
@@ -14,4 +14,4 @@
 	female_clothes = /obj/item/clothing/under/vampire/toreador/female
 	enlightenment = FALSE
 	whitelisted = TRUE
-	subsplat_keys = /obj/item/vamp/keys/daughters
+	//subsplat_keys = /obj/item/vamp/keys/daughters //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats

--- a/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/lasombra/lasombra.dm
+++ b/modular_darkpack/modules/vampire_the_masquerade/code/vampire_clan/clans/lasombra/lasombra.dm
@@ -18,7 +18,7 @@
 	male_clothes = /obj/item/clothing/under/vampire/emo
 	female_clothes = /obj/item/clothing/under/vampire/business
 	enlightenment = TRUE
-	subsplat_keys = /obj/item/vamp/keys/lasombra
+	//subsplat_keys = /obj/item/vamp/keys/lasombra //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 
 /datum/subsplat/vampire_clan/lasombra/psychomania_effect(mob/living/target, mob/living/owner)

--- a/modular_darkpack/modules/werewolf_the_apocalypse/code/subsplats/tribes/garou.dm
+++ b/modular_darkpack/modules/werewolf_the_apocalypse/code/subsplats/tribes/garou.dm
@@ -6,7 +6,7 @@
 	name = TRIBE_GALESTALKERS
 	desc = "Tireless trackers and peerless hunters, the galestalkers carry the namesake of the wind that crosses the tundra."
 	gifts_provided = list()
-	subsplat_keys = /obj/item/vamp/keys/nps
+	//subsplat_keys = /obj/item/vamp/keys/nps //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/ghostcouncil
 	name = TRIBE_GHOST_COUNCIL //TFN EDIT CHANGE - Ghost Council - Original: name = TRIBE_UKTENA
@@ -14,7 +14,7 @@
 	gifts_provided = list(
 		// /datum/action/cooldown/power/gift/spirit_speech, // DARKPACK TODO - (Selectable Gifts)
 	)
-	subsplat_keys = /obj/item/vamp/keys/nps
+	//subsplat_keys = /obj/item/vamp/keys/nps //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/hartwardens
 	name = TRIBE_HART_WARDENS //TFN EDIT CHANGE - Hart Wardens - Original: name = TRIBE_FIANNA
@@ -22,7 +22,7 @@
 	gifts_provided = list(
 		/datum/action/cooldown/power/gift/faerie_light,
 	)
-	subsplat_keys = /obj/item/vamp/keys/nps
+	//subsplat_keys = /obj/item/vamp/keys/nps //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/glasswalkers
 	name = TRIBE_GLASS_WALKERS
@@ -30,7 +30,7 @@
 	gifts_provided = list(
 		/datum/action/cooldown/power/gift/control_machine/simple,
 	)
-	subsplat_keys = /obj/item/vamp/keys/techstore
+	//subsplat_keys = /obj/item/vamp/keys/techstore //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/bonegnawers
 	name = TRIBE_BONE_GNAWERS
@@ -38,7 +38,7 @@
 	gifts_provided = list(
 		/datum/action/cooldown/power/gift/desperate_strength,
 	)
-	subsplat_keys = /obj/item/vamp/keys/children_of_gaia
+	//subsplat_keys = /obj/item/vamp/keys/children_of_gaia //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/childrenofgaia
 	name = TRIBE_CHILDREN_OF_GAIA
@@ -48,7 +48,7 @@
 		// /datum/action/cooldown/power/gift/mothers_touch, // DARKPACK TODO - (Selectable Gifts)
 		// /datum/action/cooldown/power/gift/resist_pain, // DARKPACK TODO - (Selectable Gifts)
 	)
-	subsplat_keys = /obj/item/vamp/keys/children_of_gaia
+	//subsplat_keys = /obj/item/vamp/keys/children_of_gaia //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/getoffenris
 	name = TRIBE_GET_OF_FENRIS
@@ -58,7 +58,7 @@
 		// /datum/action/cooldown/power/gift/resist_pain, // DARKPACK TODO - (Selectable Gifts)
 		/datum/action/cooldown/power/gift/visage_of_fenris,
 	)
-	subsplat_keys = /obj/item/vamp/keys/nps
+	//subsplat_keys = /obj/item/vamp/keys/nps //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/blackfuries
 	name = TRIBE_BLACK_FURIES
@@ -66,7 +66,7 @@
 	gifts_provided = list(
 		/datum/action/cooldown/power/gift/breath_of_the_wyld,
 	)
-	subsplat_keys = /obj/item/vamp/keys/nps
+	//subsplat_keys = /obj/item/vamp/keys/nps //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/silentstriders
 	name = TRIBE_SILENT_STRIDERS
@@ -75,7 +75,7 @@
 		// /datum/action/cooldown/power/gift/sense_wyrm, // DARKPACK TODO - (Selectable Gifts)
 		/datum/action/cooldown/power/gift/speed_of_thought,
 	)
-	subsplat_keys = /obj/item/vamp/keys/nps
+	//subsplat_keys = /obj/item/vamp/keys/nps //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/shadowlords
 	name = TRIBE_SHADOW_LORDS
@@ -84,7 +84,7 @@
 		/datum/action/cooldown/power/gift/aura_of_confidence,
 		/datum/action/cooldown/power/gift/fatal_flaw,
 	)
-	subsplat_keys = /obj/item/vamp/keys/techstore
+	//subsplat_keys = /obj/item/vamp/keys/techstore //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/redtalons
 	name = TRIBE_RED_TALONS
@@ -100,13 +100,13 @@
 	gifts_provided = list(
 		// /datum/action/cooldown/power/gift/inspiration, // DARKPACK TODO - (Selectable Gifts)
 	)
-	subsplat_keys = /obj/item/vamp/keys/nps
+	//subsplat_keys = /obj/item/vamp/keys/nps //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/stargazers
 	name = TRIBE_STARGAZERS
 	desc = "The calmest of the Garou, they are well known for their introversion. They are the smallest of the remaining tribes, many of their kind wiped out by the Wyrm."
 	gifts_provided = list()
-	subsplat_keys = /obj/item/vamp/keys/nps
+	//subsplat_keys = /obj/item/vamp/keys/nps //TFN EDIT REMOVE - Removes Defunct Keys and Give Relevant Keys for some Splats
 
 /datum/subsplat/werewolf/tribe/garou/blackspiraldancers
 	name = TRIBE_BLACK_SPIRAL_DANCERS

--- a/modular_tfn/modules/vampire_the_masquerade/code/vampire_clan/clans/lasombra/giovanni.dm
+++ b/modular_tfn/modules/vampire_the_masquerade/code/vampire_clan/clans/lasombra/giovanni.dm
@@ -1,0 +1,2 @@
+/datum/subsplat/vampire_clan/giovanni
+	subsplat_keys = /obj/item/vamp/keys/giovanni

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8172,6 +8172,7 @@
 #include "modular_tfn\modules\vampire_the_masquerade\code\splats\ghoul_splat\ghoul_splat.dm"
 #include "modular_tfn\modules\vampire_the_masquerade\code\splats\kindred_splat\kindred_splat.dm"
 #include "modular_tfn\modules\vampire_the_masquerade\code\vampire_clan\trusted_whitelist.dm"
+#include "modular_tfn\modules\vampire_the_masquerade\code\vampire_clan\clans\lasombra\giovanni.dm"
 #include "modular_tfn\modules\vampire_the_masquerade\code\vampire_clan\clans\lasombra\lasombra.dm"
 #include "modular_tfn\modules\vip_areas\code\bouncer_roles\bouncer_magadon_role.dm"
 #include "modular_tfn\modules\weapons\code\guns.dm"


### PR DESCRIPTION

## About The Pull Request
Removes National Park Service, Tech Shop, and Food Pantry Keys from the Garou as those places no longer exist (Minus the ranger tower, which has a pr open to  give it Nature's Bounty access.) Takes Lasombra keys as that has not been their haven in forever and it's weird for them to have access still. Takes Giovanni keys from La Squadra and gives them to the Giovanni clan splat instead. Takes the DOC's keys cause they haven't had a haven since the old map. 
## Why It's Good For The Game
Taking keys that no longer work or are for havens that don't exist / aren't owned by said splat anymore is good. It cuts down on new player confusion and cuts down on key bloat (which is very real for some subsplats). 

Giving Giovanni keys to the clan instead of La Squadra is good cause it gives all Giovanni one set of keys. Giovanni canonically work at Pentex companies and are still considered / required to be part of the family. Pentex company Giovanni (Currently just Magadon and Red Network) will no longer get cucked out of doing family stuff. 
## Changelog
:cl:Biplume
del: defunct keys removed from Garou Tribes, DOCs, and Lasombra.
balance: Giovanni keys on Clan instead of La Squadra job. 
/:cl:
