### PR TITLE
Adds Access Helpers to Doors

### DIFF
--- a/_maps/map_files/Vampire/sanfrancisco/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/sanfrancisco/SanFrancisco.dmm
@@ -10395,7 +10395,7 @@
 /obj/structure/vampdoor/prison,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/nine,
-/obj/effect/mapping_helpers/door/access/camarilla,
+/obj/effect/mapping_helpers/door/access/hound,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/millennium_tower)
 "cxE" = (
@@ -33452,7 +33452,7 @@
 /obj/structure/vampdoor/prison,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/nine,
-/obj/effect/mapping_helpers/door/access/camarilla,
+/obj/effect/mapping_helpers/door/access/hound,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower/f2)
 "igk" = (
@@ -63882,7 +63882,7 @@
 	},
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
-/obj/effect/mapping_helpers/door/access/camarilla,
+/obj/effect/mapping_helpers/door/access/hound,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower/f2)
 "poM" = (
@@ -65431,7 +65431,7 @@
 	},
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
-/obj/effect/mapping_helpers/door/access/camarilla,
+/obj/effect/mapping_helpers/door/access/hound,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/millennium_tower)
 "pJa" = (

--- a/_maps/map_files/Vampire/sanfrancisco/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/sanfrancisco/SanFrancisco.dmm
@@ -10395,6 +10395,7 @@
 /obj/structure/vampdoor/prison,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/nine,
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/millennium_tower)
 "cxE" = (
@@ -33451,6 +33452,7 @@
 /obj/structure/vampdoor/prison,
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/nine,
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower/f2)
 "igk" = (
@@ -46721,6 +46723,7 @@
 	},
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/obj/effect/mapping_helpers/door/access/sheriff,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f2)
 "lnX" = (
@@ -63879,6 +63882,7 @@
 	},
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/eight,
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower/f2)
 "poM" = (
@@ -65427,6 +65431,7 @@
 	},
 /obj/effect/mapping_helpers/door/lock,
 /obj/effect/mapping_helpers/door/lock_difficulty/six,
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/millennium_tower)
 "pJa" = (


### PR DESCRIPTION

## About The Pull Request

This is really just a quick attempt at fixing a small issue reported by players: a few doors at the MT are not opening properly with the Camarilla keys. The door to the sheriff's office, the prison across from the office and its cell doors, and the cage in the tower basement. All should now work with the keys that Hounds and above get.
## Why It's Good For The Game

Things get fixed! Things get better!
## Changelog
:cl:
fix: added Camarilla access helpers on the map to: Tower basement cage doors, tower second floor prison and cells.
fix: added Sheriff access helper to Sheriff Office's door.
/:cl:
